### PR TITLE
fix: Correct typo in package-data section of pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,5 +26,5 @@ Changelog = "https://github.com/intel/mfd-kvm/blob/main/CHANGELOG.md"
 [tool.setuptools.packages.find]
 exclude = ["examples", "tests*", "sphinx-doc"]
 
-[tools.setuptools.package-data]
+[tool.setuptools.package-data]
 "mfd_kvm" = ["*.xml"]


### PR DESCRIPTION
This pull request fixes a typo in the `pyproject.toml` configuration, ensuring that the `[tool.setuptools.package-data]` section is correctly named so that package data is included as expected.