### PR TITLE
feat: Add possibility of assigning a MAC address to VM's VF

### DIFF
--- a/mfd_kvm/hypervisor.py
+++ b/mfd_kvm/hypervisor.py
@@ -764,6 +764,7 @@ class KVMHypervisor:
         template_path: Union[Path, str] = Path(__file__).parent / "vf_template.xml",
         file_to_save: str,
         pci_address: "PCIAddress",
+        mac_address: Optional[MACAddress] = None,
     ) -> Path:
         """
         Create configuration xml of VF for QEMU.
@@ -771,6 +772,7 @@ class KVMHypervisor:
         :param template_path: Path to template config
         :param file_to_save: Path to destination directory
         :param pci_address: PCI Address of VF
+        :param mac_address: MAC address of VF, if needed to set in config
         :return: Path to saved configuration
         """
         logger.log(log_levels.MODULE_DEBUG, msg="Creating configuration file for VF.")
@@ -778,7 +780,12 @@ class KVMHypervisor:
         for key, value in asdict(pci_address).items():
             # convert int to hex required for xml
             data_for_template[key] = hex(value)
-        file_to_save = self._render_file(file_to_save, data_for_template, template_path)
+        if mac_address is not None:
+            data_for_template["mac_address"] = str(mac_address)
+            template_path_with_mac = Path(__file__).parent / "vf_template_with_mac.xml"
+            file_to_save = self._render_file(file_to_save, data_for_template, template_path_with_mac)
+        else:
+            file_to_save = self._render_file(file_to_save, data_for_template, template_path)
         return file_to_save
 
     def _render_file(

--- a/mfd_kvm/vf_template_with_mac.xml
+++ b/mfd_kvm/vf_template_with_mac.xml
@@ -1,0 +1,6 @@
+<hostdev mode='subsystem' type='pci' managed='yes'>
+    <mac address='{{mac_address}}'/>
+    <source>
+        <address domain='{{domain}}' bus='{{bus}}' slot='{{slot}}' function='{{func}}'/>
+    </source>
+</hostdev>

--- a/tests/unit/test_mfd_kvm/test_hypervisor.py
+++ b/tests/unit/test_mfd_kvm/test_hypervisor.py
@@ -798,6 +798,21 @@ class TestKVMHypervisor:
         hv.prepare_vf_xml(template_path="", file_to_save="", pci_address=PCIAddress(0, 0, 15, 1))
         hv._conn.path().write_text.assert_called_once()
 
+    def test_prepare_vf_xml_with_mac_address(self, hv, mocker):
+        template_data = b"<mac address='{{mac_address}}'/><address domain='{{domain}}' bus='{{bus}}' slot='{{slot}}' function='{{func}}'/>"
+        mocker.patch("mfd_kvm.hypervisor.open", mocker.mock_open(read_data=template_data))
+        hv._conn.path = mocker.Mock()
+        pci_address = PCIAddress(0, 0, 15, 1)
+        mac = MACAddress("AA:BB:CC:DD:EE:FF")
+
+        hv.prepare_vf_xml(template_path="", file_to_save="", pci_address=pci_address, mac_address=mac)
+
+        expected_rendered = (
+            "<mac address='aa:bb:cc:dd:ee:ff'/>"
+            "<address domain='0x0' bus='0x0' slot='0xf' function='0x1'/>"
+        )
+        hv._conn.path().write_text.assert_called_once_with(expected_rendered)
+
     def test_prepare_pci_controller_xml(self, hv, mocker):
         template_data = (
             b"index='{{index}}' chassis='{{chassis}}' port='{{port}}' bus='{{bus}}' slot='{{slot}}' "


### PR DESCRIPTION
This pull request adds support for specifying a MAC address when generating the Virtual Function (VF) XML configuration for QEMU in the `mfd_kvm` hypervisor module. The implementation includes changes to the XML generation logic, a new template, and an additional unit test to ensure correct behavior.

**Enhancements to VF XML generation:**

* Updated the `prepare_vf_xml` method in `hypervisor.py` to accept an optional `mac_address` parameter. If provided, the method uses a new template (`vf_template_with_mac.xml`) that includes the MAC address in the generated XML.
* Added a new XML template file, `vf_template_with_mac.xml`, which defines the structure for a VF with a MAC address.

**Testing improvements:**

* Added a unit test (`test_prepare_vf_xml_with_mac_address`) in `test_hypervisor.py` to verify that the MAC address is correctly rendered in the generated XML when provided.